### PR TITLE
Standardize time range prefixes to use '10min' instead of '10m' to match...

### DIFF
--- a/graphite_influxdb.py
+++ b/graphite_influxdb.py
@@ -425,7 +425,7 @@ class InfluxdbFinder(object):
             res = 21600
         elif (start_time < now- 172800) or (time_range > 10800):
             #older then 7days or for a range of more then 3hours, then show 10minute data.
-            prefix = '10m.avg.'
+            prefix = '10min.avg.'
             res = 600
 
         #else show raw data.


### PR DESCRIPTION
... the '6hour' time.

The golang metrics worker was already using "10min" and "6hour", but this and the nodejs metrics worker were using "10m" and "6hour". This just makes it a little more consistent.
